### PR TITLE
display withdrawal fee estimate

### DIFF
--- a/components/Withdraw.tsx
+++ b/components/Withdraw.tsx
@@ -25,14 +25,17 @@ const Withdraw: React.FC<{}> = () => {
   //Estimate fee
   useEffect(() => {
     (async () => {
-      const gasEstimate = (await Signer.getGasPrice()).toString();
-      const verificationFee = await Contracts.bridge.verificationFee();
+      let gasPrice = (await Signer.getGasPrice()).toString();
+      gasPrice = ethers.utils.formatUnits(gasPrice);
 
-      const totalFeeEstimate =
-        Number(ethers.utils.formatUnits(gasEstimate)) +
-        Number(ethers.utils.formatUnits(verificationFee));
+      const gasEstimate = Number(gasPrice) * 150000;
 
-      setEstimatedFee(totalFeeEstimate);
+      let verificationFee = await Contracts.bridge.verificationFee();
+      verificationFee = ethers.utils.formatUnits(verificationFee);
+
+      const totalFeeEstimate = gasEstimate + Number(verificationFee);
+
+      setEstimatedFee(Number(totalFeeEstimate.toFixed(6)));
     })();
   }, []);
 
@@ -169,6 +172,7 @@ const Withdraw: React.FC<{}> = () => {
       },
       {
         value: verificationFee,
+        gasLimit: 150000,
       }
     );
 

--- a/components/Withdraw.tsx
+++ b/components/Withdraw.tsx
@@ -159,6 +159,24 @@ const Withdraw: React.FC<{}> = () => {
       s.push(sig.s);
     });
 
+    let gasEstimate = await Contracts.peg.estimateGas.withdraw(
+      tokenAddress,
+      withdrawAmount,
+      ethAddress,
+      {
+        eventId: eventProof.eventId,
+        validatorSetId: eventProof.validatorSetId,
+        v,
+        r,
+        s,
+      },
+      {
+        value: verificationFee,
+      }
+    );
+
+    let gasLimit = (gasEstimate.toNumber() * 1.02).toFixed(0);
+
     let tx: any = await Contracts.peg.withdraw(
       tokenAddress,
       withdrawAmount,
@@ -172,7 +190,7 @@ const Withdraw: React.FC<{}> = () => {
       },
       {
         value: verificationFee,
-        gasLimit: 150000,
+        gasLimit: gasLimit,
       }
     );
 


### PR DESCRIPTION
Closes #26 

Note: This estimate is not very accurate and tends to be lower than the actual cost.

The better method:
`peg.estimateGas.withdraw();`
will not work without real values so cannot be done before the withdraw has already happened on CENNZ side